### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/v-dobaba/2180017e-e458-4966-90b6-fc003b0d6471/8789b0d5-3c32-408f-aae9-1538325ad45f/_apis/work/boardbadge/482eab19-bf09-4e8a-a03e-cf26c3717631)](https://dev.azure.com/v-dobaba/2180017e-e458-4966-90b6-fc003b0d6471/_boards/board/t/8789b0d5-3c32-408f-aae9-1538325ad45f/Microsoft.RequirementCategory)
 
 ## Contributing
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/v-dobaba/2180017e-e458-4966-90b6-fc003b0d6471/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.